### PR TITLE
only major versions for GHA

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -23,8 +23,8 @@
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
          environment-file: [ci/36.yaml, ci/37.yaml, ci/38.yaml]
      steps:
-       - uses: actions/checkout@v2.3.4
-       - uses: conda-incubator/setup-miniconda@v2.0.0
+       - uses: actions/checkout@v2
+       - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
             auto-update-conda: true
@@ -38,7 +38,7 @@
        - shell: bash -l {0}
          run: py.test -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml
        - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
-         uses: codecov/codecov-action@v1.0.15
+         uses: codecov/codecov-action@v1
          with:
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml


### PR DESCRIPTION
This PR allows dependabot to check for only major versions in GitHub Actions.