### PR TITLE
add release and publish GHA

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -1,0 +1,68 @@
+# This file is part of the Minnesota Population Center's NHGISXWALK.
+# For copyright and licensing information, see the NOTICE and LICENSE files
+# in this project's top-level directory, and also on-line at:
+#   https://github.com/ipums/nhgisxwalk
+
+name: release_and_publish
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine jupyter urllib3 pandas pyyaml
+        python setup.py sdist bdist_wheel
+    - name: Run Changelog
+      run: |
+        jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=python3 tools/gitcount.ipynb
+    - name: Cat Changelog
+      uses: pCYSl5EDgo/cat@master
+      id: changetxt
+      with:
+        path: ./tools/changelog.md
+      env:
+        TEXT: ${{ steps.changetxt.outputs.text }}
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # token is provided by GHA, DO NOT create
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: ${{ steps.changetxt.outputs.text }}
+        draft: false
+        prerelease: false
+    - name: Get Asset name
+      run: |
+        export PKG=$(ls dist/)
+        set -- $PKG
+        echo "whl_path=1" >> $GITHUB_ENV
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ env.whl_path }}
+        asset_name: ${{ env.whl_path }}
+        asset_content_type: application/zip
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This PR add a release and publish action. This action is triggered by pushing a [tagged commit](https://git-scm.com/book/en/v2/Git-Basics-Tagging) ***directly*** to the main branch with the following pattern: `'v*'` i.e. `v2.0` or `v5.4.3`.