### PR TITLE
implement micromamba for CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,7 +25,7 @@
      steps:
        - name: checkout repo
          uses: actions/checkout@v2
-       
+
        - name: setup micromamba
          uses: mamba-org/provision-with-micromamba@main
          with:
@@ -48,32 +48,3 @@
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml
            name: nhgisxwalk-codecov
-     
-     
-     
-     
-     #efaults:
-     # run:
-     #   shell: bash -l {0}
-     #teps:
-     # - uses: actions/checkout@v2
-     # - uses: actions/cache@v2
-     #   env:
-     #     CACHE_NUMBER: 0
-     #   with:
-     #     path: ~/conda_pkgs_dir
-     #     key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
-     # - uses: conda-incubator/setup-miniconda@v2
-     #   with:
-     #      miniconda-version: 'latest'
-     #      mamba-version: "*"
-     #      channels: conda-forge
-     #      channel-priority: true
-     #      auto-update-conda: false
-     #      auto-activate-base: false
-     #      environment-file: ${{ matrix.environment-file }}
-     #      activate-environment: test
-     #      use-only-tar-bz2: true
-     # - run: mamba info --all
-     # - run: mamba list
-     # - run: pytest -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,41 +15,65 @@
 
  jobs:
    unittests:
-     name: conda (${{ matrix.os }}, ${{ matrix.environment-file }})
+     name: micromamba (${{ matrix.os }}, ${{ matrix.environment-file }})
      runs-on: ${{ matrix.os }}
      timeout-minutes: 10
      strategy:
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
          environment-file: [ci/36.yaml, ci/37.yaml, ci/38.yaml, ci/39.yaml]
-     defaults:
-       run:
-         shell: bash -l {0}
      steps:
-       - uses: actions/checkout@v2
-       - uses: actions/cache@v2
-         env:
-           CACHE_NUMBER: 0
+       - name: checkout repo
+         uses: actions/checkout@v2
+       
+       - name: setup micromamba
+         uses: mamba-org/provision-with-micromamba@main
          with:
-           path: ~/conda_pkgs_dir
-           key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
-       - uses: conda-incubator/setup-miniconda@v2
-         with:
-            miniconda-version: 'latest'
-            mamba-version: "*"
-            channels: conda-forge
-            channel-priority: true
-            auto-update-conda: false
-            auto-activate-base: false
-            environment-file: ${{ matrix.environment-file }}
-            activate-environment: test
-            use-only-tar-bz2: true
-       - run: mamba info --all
-       - run: mamba list
-       - run: pytest -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml
-       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
+           environment-file: ${{ matrix.environment-file }}
+           micromamba-version: 'latest'
+
+       - name: run tests - bash
+         shell: bash -l {0}
+         run: pytest -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         if: matrix.os != 'windows-latest'
+       
+       - name: run tests - powershell
+         shell: powershell
+         run: pytest -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml
+         if: matrix.os == 'windows-latest'
+     
+       - name: codecov
          uses: codecov/codecov-action@v1
          with:
            token: ${{ secrets.CODECOV_TOKEN }}
            file: ./coverage.xml
            name: nhgisxwalk-codecov
+     
+     
+     
+     
+     #efaults:
+     # run:
+     #   shell: bash -l {0}
+     #teps:
+     # - uses: actions/checkout@v2
+     # - uses: actions/cache@v2
+     #   env:
+     #     CACHE_NUMBER: 0
+     #   with:
+     #     path: ~/conda_pkgs_dir
+     #     key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
+     # - uses: conda-incubator/setup-miniconda@v2
+     #   with:
+     #      miniconda-version: 'latest'
+     #      mamba-version: "*"
+     #      channels: conda-forge
+     #      channel-priority: true
+     #      auto-update-conda: false
+     #      auto-activate-base: false
+     #      environment-file: ${{ matrix.environment-file }}
+     #      activate-environment: test
+     #      use-only-tar-bz2: true
+     # - run: mamba info --all
+     # - run: mamba list
+     # - run: pytest -v nhgisxwalk --cov=nhgisxwalk --doctest-modules --cov-config=.coveragerc --cov-report=xml


### PR DESCRIPTION
This PR implements the [`provision-with-micromamba`](https://github.com/mamba-org/provision-with-micromamba) GitHub Action for setting up the Python installations for continuous integration. Total time for CI tests decrease from [~8 minutes](https://github.com/ipums/nhgisxwalk/actions/runs/783861568) to [~3 minutes](https://github.com/ipums/nhgisxwalk/actions/runs/783905160).