### PR TITLE
remove pypi push

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Manual CI Reason
+        description: Manual Release Reason
         default: test
         required: false
 
@@ -60,8 +60,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
+      #- name: Publish distribution 📦 to PyPI
+      #  uses: pypa/gh-action-pypi-publish@master
+      #  with:
+      #    user: __token__
+      #    password: ${{ secrets.PYPI_PASSWORD }}

--- a/nhgisxwalk/__init__.py
+++ b/nhgisxwalk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 """
 # `nhgisxwalk` --- IPUMS/NHGIS Census Crosswalk and Atom Generator
 


### PR DESCRIPTION
This PR removes the 'publish to PyPI' portion of the `release_and_publish.yml` since `nhgisxwalk` is not currently published there.