### PR TITLE
add 3.10 to CI testing support

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,7 +27,7 @@
      strategy:
        matrix:
          os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-         environment-file: [ci/37.yaml, ci/38.yaml, ci/39.yaml]
+         environment-file: [ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml]
      steps:
        - name: checkout repo
          uses: actions/checkout@v2

--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -1,0 +1,18 @@
+# This file is part of the Minnesota Population Center's NHGISXWALK.
+# For copyright and licensing information, see the NOTICE and LICENSE files
+# in this project's top-level directory, and also on-line at:
+#   https://github.com/ipums/nhgisxwalk
+
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  # required
+  - numpy>=1.3
+  - pandas>=1.0
+  - watermark
+  # testing
+  - pytest
+  - pytest-cov
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@
 #   https://github.com/ipums/nhgisxwalk
 codecov:
   notify:
-    after_n_builds: 3
+    after_n_builds: 12
 coverage:
   range: 50...90
   round: nearest
@@ -22,5 +22,5 @@ coverage:
 comment:
   layout: "reach, diff, files"
   behavior: once
-  after_n_builds: 3
+  after_n_builds: 12
   require_changes: true

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ def setup_package():
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
         ],
         license="MPL-2.0",
         packages=[package],


### PR DESCRIPTION
This PR adds Python 3.10 to the GHA CI testing matrix.