### PR TITLE
streamline matrix logic / drop 3.7

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -26,8 +26,14 @@
      timeout-minutes: 10
      strategy:
        matrix:
-         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
-         environment-file: [ci/37.yaml, ci/38.yaml, ci/39.yaml, ci/310.yaml]
+         environment-file: [ci/38.yaml, ci/39.yaml, ci/310.yaml]
+         os: ['ubuntu-latest']
+         include:
+           - environment-file: ci/310.yaml
+             os: macos-latest
+           - environment-file: ci/310.yaml
+             os: windows-latest
+     
      steps:
        - name: checkout repo
          uses: actions/checkout@v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@
 #   https://github.com/ipums/nhgisxwalk
 codecov:
   notify:
-    after_n_builds: 12
+    after_n_builds: 5
 coverage:
   range: 50...90
   round: nearest
@@ -22,5 +22,5 @@ coverage:
 comment:
   layout: "reach, diff, files"
   behavior: once
-  after_n_builds: 12
+  after_n_builds: 5
   require_changes: true


### PR DESCRIPTION
This PR:
* streamlines GHA testing matrix logic
* only only macOS & Windows for Python 3.10
* drop testing for Python 3.7